### PR TITLE
feat: Adding AED currency to help fellow shababs to negotiate bitcoin properly

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -49,7 +49,7 @@ const sats = computed(() => {
 })
 
 const currency = ref('brl')
-const currencies = ['brl', 'usd', 'eur']
+const currencies = ['brl', 'usd', 'eur', 'aed']
 const currencySymbol = computed(() => {
   if (!rates.value) return ''
   if (!rates.value[currency.value]) return ''


### PR DESCRIPTION
As-salamu alaykum

Since I came to UAE, finding a handy bitcoin pricing calculator was hell as this magnificent app did not have AED currency available. Apparently, we were expected to calculate our oil-wealth-to-sats ratio using USD like peasants.

I’ve rectified this oversight in app.vue by adding AED to the currencies array. Now, my fellow shababs can finally negotiate Bitcoin prices at the majlis or while stuck in Sheikh Zayed Road traffic without having to do mental math.

What’s changing?
`app.vue`: Added 'aed' to the currencies constant.

That’s it. One small string for the code, one giant leap for the Habibi economy. 🇦🇪 ₿

<img width="817" height="1029" alt="image" src="https://github.com/user-attachments/assets/d88dcd08-cc32-4a50-b027-b18836be476a" />

(This PR is halal)